### PR TITLE
Fix stack effects

### DIFF
--- a/src/main/scala/cafebabe/ByteCodes.scala
+++ b/src/main/scala/cafebabe/ByteCodes.scala
@@ -205,7 +205,7 @@ object ByteCodes {
   case object POP2 extends ByteCode(0x58, -2, 1)
   case object POP extends ByteCode(0x57, -1, 1)
   case object PUTFIELD extends ByteCode(0xB5, -2, 3)
-  case object PUTSTATIC extends ByteCode(0xB3, None, 3)
+  case object PUTSTATIC extends ByteCode(0xB3, -1, 3)
   case object RET extends ByteCode(0xA9, 0, 2)
   case object RETURN extends ByteCode(0xB1, 0, 1)
   case object SALOAD extends ByteCode(0x35, -1, 1)

--- a/src/main/scala/cafebabe/ByteCodes.scala
+++ b/src/main/scala/cafebabe/ByteCodes.scala
@@ -204,7 +204,7 @@ object ByteCodes {
   case object NOP extends ByteCode(0x0, 0, 1)
   case object POP2 extends ByteCode(0x58, -2, 1)
   case object POP extends ByteCode(0x57, -1, 1)
-  case object PUTFIELD extends ByteCode(0xB5, None, 3)
+  case object PUTFIELD extends ByteCode(0xB5, -2, 3)
   case object PUTSTATIC extends ByteCode(0xB3, None, 3)
   case object RET extends ByteCode(0xA9, 0, 2)
   case object RETURN extends ByteCode(0xB1, 0, 1)


### PR DESCRIPTION
`PUTFIELD` bytecode now has a stack effect of -2 instead of None.
According to the specification the objectref and the value are
popped from the stack.

See: https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html#jvms-6.5.putfield

`PUTSTATIC` bytecode now has a stack effect of -1 instead of None.
According to the specification the value is popped from the stack.

See: https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html#jvms-6.5.putstatic