### PR TITLE
Add 2.12.1 to cross-versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: scala
 scala:
     - 2.10.4
     - 2.11.8
+    - 2.12.1

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "Cafebabe"
 
 version := "1.2"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
-crossScalaVersions := Seq("2.10.4", "2.11.8")
+crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.1")
 
 scalacOptions += "-deprecation"
 
@@ -12,5 +12,5 @@ scalacOptions += "-unchecked"
 
 scalacOptions += "-Xexperimental"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 


### PR DESCRIPTION
Also, bump the default version to 2.12.1.

Sbt seems to have a pretty significant limitation for github source dependencies as overriding the scalaVersion in a dependency is highly unstable (if at all possible). We have found a couple bugs in the 2.11.8 compiler when using path-dependent types that require us to use 2.12 for Stainless, so Stainless needs cafebabe to have (some flavor of) 2.12 as its scalaVersion. I don't really like this requirement, so WDYT of cross-publishing cafebabe on some repo? The project seems stable enough :)

I can fork cafebabe onto epfl-lara and publish it from there if you're ok with that.