### PR TITLE
parseRec substring index problem

### DIFF
--- a/src/main/scala/cafebabe/package.scala
+++ b/src/main/scala/cafebabe/package.scala
@@ -56,7 +56,7 @@ package object cafebabe {
       case 'L' => {
         val end = s.indexOf(';')
         if(end < 0) sys.error("Malformed type (sub)string: " + s)
-        (1, s.substring(0, end), s.substring(end + 1, s.size))
+        (1, s.substring(0, end + 1), s.substring(end + 1, s.size))
       }
       case '[' => {
         if(s.tail.isEmpty) sys.error("Malformed type string: incomplete array type.")


### PR DESCRIPTION
### Original Code in `package.scala`:
``` scala
private def parseRec(s : String) : (Int,String,String) = if(s.isEmpty)  (0,s,s) else {
    s.head match {
      ...
      case 'L' => {
        val end = s.indexOf(';')
        if(end < 0) sys.error("Malformed type (sub)string: " + s)
        (1, s.substring(0, end), s.substring(end + 1, s.size))
      }
      ...
      case _ => sys.error("Malformed type (sub)string: " + s)
    }
  }
```
I think the original code `case 'L' => {... (1, s.substring(0, end), ...) ...}` should be be `case 'L' => {... (1, s.substring(0, end + 1), ...) ...}` since the parameter `end` in method `substring` is exclusive, therefore:


### After
``` scala
private def parseRec(s : String) : (Int,String,String) = if(s.isEmpty)  (0,s,s) else {
    s.head match {
      ...
      case 'L' => {
        val end = s.indexOf(';')
        if(end < 0) sys.error("Malformed type (sub)string: " + s)
        (1, s.substring(0, end + 1), s.substring(end + 1, s.size))
      }
      ...
      case _ => sys.error("Malformed type (sub)string: " + s)
    }
  }
```
